### PR TITLE
Fix perspective references in examples

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -236,7 +236,7 @@ Characters whose actions and motivations reveal deeper thematic layers (subtext)
     ],
     "perspectives": [
         {
-            "perspective_id": "persp_def456"
+            "perspective_id": "perspective_ab12cd34"
         }
     ]
   }
@@ -259,7 +259,7 @@ Defined structural elements representing spatial aspects of a narrative. They es
     "storytelling": "Michael takes charge, justifying his actions as necessary in order to take care of the family.",
     "perspectives": [
         {
-            "perspective_id": "persp_def456"
+            "perspective_id": "perspective_ab12cd34"
         }
     ]
   }

--- a/docs/narrative-context-protocol-schema.md
+++ b/docs/narrative-context-protocol-schema.md
@@ -253,7 +253,7 @@ Structured **spatial aspects** that define and shape the narrative.
     "storytelling": "Michael takes charge, justifying his actions as necessary in order to take care of the family.",
     "perspectives": [
         {
-            "perspective_id": "persp_def456"
+            "perspective_id": "perspective_ab12cd34"
         }
     ]
   }

--- a/examples/example-story.json
+++ b/examples/example-story.json
@@ -27,7 +27,7 @@
                 "summary": "A dedicated detective haunted by unresolved cases.",
                 "storytelling": "John exudes a stoic demeanor, masking the inner turmoil of his past.",
                 "perspective": {
-                  "throughline": "Objective Story",
+                  "throughline": "Main Character",
                   "perspective_id": "perspective_12345678-1234-1234-1234-123456789012"
                 },
                 "motivations": [


### PR DESCRIPTION
## Summary
- update player perspective example
- keep perspective IDs consistent in SPECIFICATION and docs

## Testing
- `node tests/validate-schema.js` *(fails: Cannot find module 'ajv')*

------
https://chatgpt.com/codex/tasks/task_e_68447f62c93c832dbcd005a376f93028