### PR TITLE
[codex] sanitize NCP grounding language

### DIFF
--- a/NCP_SEMANTIC_GROUNDING.md
+++ b/NCP_SEMANTIC_GROUNDING.md
@@ -4,9 +4,9 @@ The Narrative Context Protocol (NCP) is a transport format for preserving narrat
 
 This file is a semantic interoperability guide. It is not a replacement for Dramatica theory, canonical analysis, the Dramatica Narrative Platform, Narrova, Subtxt, or any other product-side reasoning workflow.
 
-## Defensibility Boundary
+## Interoperability Boundary
 
-NCP is open so story context can travel without collapsing into loose prose. Dramatica's deeper value remains in the theory, canonical library, analytical methods, corpus-backed interpretation, and product workflows that help writers discover and refine meaning.
+NCP gives story context a shared structure so it can travel without collapsing into loose prose. This guide keeps the public schema focused on interoperability while pointing deeper theory instruction, canonical analysis, corpus-backed interpretation, and guided authoring workflows to the Dramatica platform.
 
 Use this file to:
 
@@ -21,8 +21,6 @@ Do not use this file as:
 - a source of canonical story analysis;
 - a substitute for Storyform diagnosis;
 - a recipe for reproducing Narrova, Subtxt, or Dramatica platform behavior.
-
-The public posture is: open protocol, proprietary depth.
 
 ## Core Rule
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ In 2025, **Write Brothers®**—creators of Dramatica® and Movie Magic Screenwr
 
 Begin by reading the complete [Specification](/SPECIFICATION.md)
 
-For AI and tool consumers, read [NCP Semantic Grounding](/NCP_SEMANTIC_GROUNDING.md) before interpreting Dramatica-informed fields. It explains how to preserve term boundaries, avoid generic-storytelling substitutions, and keep Subtext separate from Storytelling without turning the open protocol into a replacement for Dramatica analysis.
+For AI and tool consumers, read [NCP Semantic Grounding](/NCP_SEMANTIC_GROUNDING.md) before interpreting Dramatica-informed fields. It explains how to preserve term boundaries, avoid generic-storytelling substitutions, and keep Subtext separate from Storytelling without treating the schema as a replacement for Dramatica analysis.
 
 Install validation dependencies and run fixture checks:
 


### PR DESCRIPTION
## Summary

Updates the NCP semantic grounding docs to use neutral interoperability language throughout.

Changes:

- renames the opening boundary section to `Interoperability Boundary`
- removes product-strategy phrasing from the public grounding guide
- softens the README link copy so it describes schema boundaries without extra positioning language

## Why

The semantic grounding guide should read as public implementation guidance for AI and tool consumers. This keeps the document focused on accurate NCP interpretation, term boundaries, and schema usage.

## Validation

- `git diff --cached --check`
- `npm run validate:schema` -> `Schema validation checks passed (8 valid + 11 invalid fixtures).`