### PR TITLE
updates: add named story driver dynamics

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## Recent Schema Updates
 
+- Added five named Story Driver Dynamic identifiers: `initial_story_driver`, `second_story_driver`, `midpoint_story_driver`, `fourth_story_driver`, and `concluding_story_driver`. They use the same `action` or `decision` vector as the singular `story_driver` Dynamic and are not Storybeats.
 - Moved canonical Moments to required `story.moments[]` so storytelling units belong to the story and can reference Storybeats and Storypoints across multiple narratives.
 - Added narrative-qualified `story.moments[].storybeats[]` and `story.moments[].storypoints[]` references, requiring `narrative_id` on each referenced structural element.
 - Removed `narratives[].storytelling.moments[]` so canonical payloads have one unambiguous Moment home.

--- a/docs/narrative-context-protocol-schema.md
+++ b/docs/narrative-context-protocol-schema.md
@@ -237,6 +237,11 @@ Canonical `dynamic` values:
 - `problem_solving_style`
 - `story_limit`
 - `story_driver`
+- `initial_story_driver`
+- `second_story_driver`
+- `midpoint_story_driver`
+- `fourth_story_driver`
+- `concluding_story_driver`
 - `story_outcome`
 - `story_judgment`
 

--- a/docs/terminology/04.dynamics.md
+++ b/docs/terminology/04.dynamics.md
@@ -56,35 +56,35 @@
         "context": "Plot",
         "short_definition": "The event that sets the Objective Story in motion.",
         "kind": "driver_dynamic",
-        "identifier": "initial_driver"
+        "identifier": "initial_story_driver"
       },
       {
         "dynamic": "Second Story Driver",
         "context": "Plot",
         "short_definition": "The event that moves the story into Act Two.",
         "kind": "driver_dynamic",
-        "identifier": "second_driver"
+        "identifier": "second_story_driver"
       },
       {
         "dynamic": "Midpoint Story Driver",
         "context": "Plot",
         "short_definition": "The event that pivots the middle of the story.",
         "kind": "driver_dynamic",
-        "identifier": "midpoint_driver"
+        "identifier": "midpoint_story_driver"
       },
       {
         "dynamic": "Fourth Story Driver",
         "context": "Plot",
         "short_definition": "The event that launches Act Three.",
         "kind": "driver_dynamic",
-        "identifier": "fourth_driver"
+        "identifier": "fourth_story_driver"
       },
       {
         "dynamic": "Concluding Story Driver",
         "context": "Plot",
         "short_definition": "The event that resolves the Objective Story's primary inequity.",
         "kind": "driver_dynamic",
-        "identifier": "concluding_driver"
+        "identifier": "concluding_story_driver"
       }
     ]
   },

--- a/examples/complete-space-adventure-storyform.json
+++ b/examples/complete-space-adventure-storyform.json
@@ -110,6 +110,13 @@
                             "storytelling": "A false beacon, a stolen gate key, a convoy jump, and a manual lock attempt each trigger the next escalation. The story advances because people act under pressure, not because they sit with a decision."
                         },
                         {
+                            "id": "dyn_anon_0009",
+                            "dynamic": "midpoint_story_driver",
+                            "vector": "action",
+                            "summary": "Nessa manually jumps the damaged convoy through the unstable gate.",
+                            "storytelling": "At the midpoint, Nessa commits the convoy to an untested route. The action exposes the sabotage, strands the remaining ships, and forces every faction to respond to the gate network's collapse."
+                        },
+                        {
                             "id": "dyn_anon_0006",
                             "dynamic": "story_limit",
                             "vector": "optionlock",

--- a/schema/ncp-schema.json
+++ b/schema/ncp-schema.json
@@ -240,6 +240,11 @@
                                                         "problem_solving_style",
                                                         "story_limit",
                                                         "story_driver",
+                                                        "initial_story_driver",
+                                                        "second_story_driver",
+                                                        "midpoint_story_driver",
+                                                        "fourth_story_driver",
+                                                        "concluding_story_driver",
                                                         "story_outcome",
                                                         "story_judgment"
                                                     ]

--- a/schema/ncp-schema.yaml
+++ b/schema/ncp-schema.yaml
@@ -187,6 +187,11 @@ properties:
                                                 - problem_solving_style
                                                 - story_limit
                                                 - story_driver
+                                                - initial_story_driver
+                                                - second_story_driver
+                                                - midpoint_story_driver
+                                                - fourth_story_driver
+                                                - concluding_story_driver
                                                 - story_outcome
                                                 - story_judgment
                                             vector:


### PR DESCRIPTION
## What changed

- add canonical Dynamic identifiers for Initial, Second, Midpoint, Fourth, and Concluding Story Drivers
- keep the singular `story_driver` as the Action/Decision structural Dynamic
- correct terminology identifiers, update schema reference/history, and add a representative named-driver example
- keep JSON and YAML schema twins synchronized

## Why

Named Story Drivers are distinct record-backed Dynamic components, not Storybeats. The canonical schema previously allowed only the singular Story Driver and forced downstream applications to use legacy representations.

## Validation

- schema validation passed for 8 valid and 11 invalid fixtures
- representative complete Storyform example validates
- JSON and YAML schema twins are structurally identical
- `git diff --check` passed